### PR TITLE
Redesign site: framework-free homepage, dark mode, accessibility, SEO

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>404 — Page not found · Issack John</title>
+        <meta name="robots" content="noindex" />
+        <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
+        <link rel="stylesheet" href="/assets/styles.css" />
+        <script>
+            (function () {
+                try {
+                    var t = localStorage.getItem("theme");
+                    if (t === "light" || t === "dark") document.documentElement.setAttribute("data-theme", t);
+                } catch (e) {}
+            })();
+        </script>
+    </head>
+    <body>
+        <main class="wrap" style="min-height: 80vh; display: grid; place-content: center; text-align: center; gap: 1rem">
+            <div class="avatar" aria-hidden="true" style="margin-bottom: 0.5rem">404</div>
+            <h1 style="margin: 0; font-size: 2rem">Page not found</h1>
+            <p style="color: var(--text-muted); margin: 0">The page you're looking for doesn't exist or has moved.</p>
+            <p style="margin: 0.5rem 0 0"><a href="/">&larr; Back to home</a></p>
+        </main>
+    </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,37 +1,61 @@
 # issackjohn.github.io
 
-Personal site for [Issack John](https://issackjohn.github.io) — Web Performance Engineer at Microsoft Edge.
+Personal site for **Issack John** — Web Performance Engineer at Microsoft Edge and core
+contributor to [Speedometer 3.0](https://browserbench.org/Speedometer3.0/).
 
-**Live site:** https://issackjohn.github.io
+**Live:** https://issackjohn.github.io
+
+## Highlights
+
+-   **Zero runtime frameworks.** The homepage ships hand-tuned CSS and a small vanilla-JS
+    enhancement layer — no Tailwind CDN, no build step. Fitting for a performance site.
+-   **Dark mode** that respects the OS preference and remembers a manual override (no flash on load).
+-   **Accessible**: semantic landmarks, a skip link, visible focus styles, and `prefers-reduced-motion` support.
+-   **SEO-ready**: meta description, Open Graph/Twitter tags, canonical URL, and JSON-LD `Person` structured data.
+
+## Structure
+
+```
+.
+├── index.html          # Portfolio home
+├── 404.html            # Friendly not-found page
+├── assets/
+│   ├── styles.css      # Theme tokens, layout, components, dark mode
+│   ├── main.js         # Theme toggle + content rendering + scroll reveal
+│   └── favicon.svg     # Inline-gradient "IJ" mark
+└── speedometer*.html   # Benchmark runners (see below)
+```
 
 ## Pages
 
-| Page | Description |
-|------|-------------|
-| [index.html](index.html) | Portfolio home — about, blog posts, projects, and links |
-| [speedometer.html](speedometer.html) | Speedometer 3.0 test runner with side-by-side suite comparison |
-| [speedometer-with-complex.html](speedometer-with-complex.html) | Benchmark experiments with complex DOM structures (June 2023) |
-| [speedometer-with-new-structure.html](speedometer-with-new-structure.html) | Updated complex DOM architecture experiments (September 2023) |
-| [complex-workloads.html](complex-workloads.html) | Browse and launch individual complex benchmark workloads |
-| [hang.html](hang.html) | Page-hang debugging tool |
+| Page                                                                       | Description                                                    |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| [index.html](index.html)                                                   | Portfolio home — about, projects, writing, and links           |
+| [speedometer.html](speedometer.html)                                       | Speedometer 3.0 test runner with side-by-side suite comparison |
+| [complex-workloads.html](complex-workloads.html)                           | Browse and launch individual complex benchmark workloads       |
+| [speedometer-with-complex.html](speedometer-with-complex.html)             | Benchmark experiments with complex DOM structures (June 2023)  |
+| [speedometer-with-new-structure.html](speedometer-with-new-structure.html) | Updated complex DOM architecture experiments (September 2023)  |
+| [hang.html](hang.html)                                                     | Page-hang debugging sandbox                                    |
 
-## Submodules
+## Benchmark variants (git submodules)
 
-Several Speedometer benchmark variants are included as git submodules:
-
-| Submodule | Description |
-|-----------|-------------|
-| `Speedometer1` | Fork with complex DOM workloads added |
-| `Speedometer2` | Speedometer 2.x variant |
-| `Speedometer3` | Speedometer 3.0 reference |
-| `SpeedometerJSWebComponents` | JavaScript Web Components implementation |
-| `SpeedometerWithBacklogOpen` | Speedometer with backlog panel open |
-| `SpeedometerWithReminderOpen` | Speedometer with reminder panel open |
-| `SpeedometerWithComplex` | Speedometer with complex workload additions |
+| Submodule                     | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `Speedometer1`                | Fork with complex DOM workloads added       |
+| `Speedometer2`                | Speedometer 2.x variant                     |
+| `Speedometer3`                | Speedometer 3.0 reference                   |
+| `SpeedometerJSWebComponents`  | JavaScript Web Components implementation    |
+| `SpeedometerWithBacklogOpen`  | Speedometer with backlog panel open         |
+| `SpeedometerWithReminderOpen` | Speedometer with reminder panel open        |
+| `SpeedometerWithComplex`      | Speedometer with complex workload additions |
 
 ## Development
 
 ```bash
-npm install      # install dev dependencies (Prettier)
-npm run format   # format HTML/JS files
+npm install            # install dev dependencies
+npm start              # serve locally with @web/dev-server (live reload)
+npm run pretty:check   # check formatting
+npm run pretty:fix     # auto-format HTML / JS / CSS
 ```
+
+The site is static — any file server (or GitHub Pages) will serve it directly.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # issackjohn.github.io
+
+Personal site for [Issack John](https://issackjohn.github.io) — Web Performance Engineer at Microsoft Edge.
+
+**Live site:** https://issackjohn.github.io
+
+## Pages
+
+| Page | Description |
+|------|-------------|
+| [index.html](index.html) | Portfolio home — about, blog posts, projects, and links |
+| [speedometer.html](speedometer.html) | Speedometer 3.0 test runner with side-by-side suite comparison |
+| [speedometer-with-complex.html](speedometer-with-complex.html) | Benchmark experiments with complex DOM structures (June 2023) |
+| [speedometer-with-new-structure.html](speedometer-with-new-structure.html) | Updated complex DOM architecture experiments (September 2023) |
+| [complex-workloads.html](complex-workloads.html) | Browse and launch individual complex benchmark workloads |
+| [hang.html](hang.html) | Page-hang debugging tool |
+
+## Submodules
+
+Several Speedometer benchmark variants are included as git submodules:
+
+| Submodule | Description |
+|-----------|-------------|
+| `Speedometer1` | Fork with complex DOM workloads added |
+| `Speedometer2` | Speedometer 2.x variant |
+| `Speedometer3` | Speedometer 3.0 reference |
+| `SpeedometerJSWebComponents` | JavaScript Web Components implementation |
+| `SpeedometerWithBacklogOpen` | Speedometer with backlog panel open |
+| `SpeedometerWithReminderOpen` | Speedometer with reminder panel open |
+| `SpeedometerWithComplex` | Speedometer with complex workload additions |
+
+## Development
+
+```bash
+npm install      # install dev dependencies (Prettier)
+npm run format   # format HTML/JS files
+```

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+    <defs>
+        <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#2563eb" />
+            <stop offset="1" stop-color="#7c3aed" />
+        </linearGradient>
+    </defs>
+    <rect width="64" height="64" rx="14" fill="url(#g)" />
+    <text x="50%" y="52%" dy="0.36em" text-anchor="middle"
+          font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+          font-size="34" font-weight="700" fill="#ffffff">IJ</text>
+</svg>

--- a/assets/main.js
+++ b/assets/main.js
@@ -1,0 +1,179 @@
+// Theme toggle: persists preference, falls back to OS setting.
+(function () {
+    const root = document.documentElement;
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+        root.setAttribute("data-theme", stored);
+    }
+
+    function currentTheme() {
+        const explicit = root.getAttribute("data-theme");
+        if (explicit) return explicit;
+        return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        const toggle = document.getElementById("themeToggle");
+        if (toggle) {
+            toggle.addEventListener("click", function () {
+                const next = currentTheme() === "dark" ? "light" : "dark";
+                root.setAttribute("data-theme", next);
+                localStorage.setItem("theme", next);
+                toggle.setAttribute("aria-pressed", String(next === "dark"));
+            });
+        }
+
+        renderContent();
+        setupReveal();
+    });
+
+    // --- Dynamic content ---------------------------------------------------
+
+    const blogPosts = [
+        {
+            title: "Contributing to Speedometer 3.0",
+            summary: "How a cross-browser team captured real-world web application challenges in the industry-standard benchmark.",
+            url: "https://blogs.windows.com/msedgedev/2024/03/11/contributing-to-speedometer-30/",
+            date: "March 11, 2024",
+        },
+    ];
+
+    const projects = [
+        {
+            title: "Speedometer 3.0 Test Runner",
+            desc: "Compare benchmark suites side-by-side and launch individual workloads.",
+            date: "Jan 2024",
+            url: "/speedometer.html",
+            external: false,
+        },
+        {
+            title: "Complex Workloads Explorer",
+            desc: "Browse and launch individual complex DOM benchmark workloads.",
+            date: "",
+            url: "/complex-workloads.html",
+            external: false,
+        },
+        {
+            title: "Speedometer with Complex DOM",
+            desc: "Benchmark experiments using deeper, more realistic DOM structures.",
+            date: "Jun 2023",
+            url: "/speedometer-with-complex.html",
+            external: false,
+        },
+        {
+            title: "Speedometer — New Structure Complex DOM",
+            desc: "Updated architecture experiments built on the complex-DOM workloads.",
+            date: "Sep 2023",
+            url: "/speedometer-with-new-structure.html",
+            external: false,
+        },
+        {
+            title: "JavaScript Web Components Speedometer",
+            desc: "TodoMVC benchmark implemented with native Web Components.",
+            date: "",
+            url: "https://issackjohn.github.io/SpeedometerJSWebComponents",
+            external: true,
+        },
+    ];
+
+    const videos = [
+        {
+            title: "Jim Rohn — Give To Receive",
+            url: "https://youtu.be/Lp3e1C54jZM?si=S_DvlMjmYVTo4exo",
+        },
+    ];
+
+    function el(tag, className, text) {
+        const node = document.createElement(tag);
+        if (className) node.className = className;
+        if (text != null) node.textContent = text;
+        return node;
+    }
+
+    function externalAttrs(a) {
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+    }
+
+    function renderContent() {
+        const blogList = document.getElementById("blogPostsList");
+        if (blogList) {
+            blogPosts.forEach(function (post) {
+                const article = el("article", "post");
+                article.appendChild(el("h3", null, post.title));
+                article.appendChild(el("p", null, post.summary));
+
+                const foot = el("div", "post-foot");
+                const a = el("a", null, "Read more \u2192");
+                a.href = post.url;
+                externalAttrs(a);
+                const time = el("time", null, post.date);
+                foot.appendChild(a);
+                foot.appendChild(time);
+                article.appendChild(foot);
+                blogList.appendChild(article);
+            });
+        }
+
+        const projectList = document.getElementById("projectsList");
+        if (projectList) {
+            projects.forEach(function (p) {
+                const a = el("a", "item");
+                a.href = p.url;
+                if (p.external) externalAttrs(a);
+
+                const head = el("div", "item-head");
+                const title = el("span", "item-title", p.title);
+                head.appendChild(title);
+                if (p.date) head.appendChild(el("span", "item-date", p.date));
+                a.appendChild(head);
+
+                const desc = el("p", "item-desc");
+                desc.innerHTML = "";
+                desc.appendChild(document.createTextNode(p.desc + " "));
+                const arrow = el("span", "arrow", "\u2192");
+                desc.appendChild(arrow);
+                a.appendChild(desc);
+                projectList.appendChild(a);
+            });
+        }
+
+        const videosList = document.getElementById("videosList");
+        if (videosList) {
+            videos.forEach(function (v) {
+                const a = el("a", "item");
+                a.href = v.url;
+                externalAttrs(a);
+                const head = el("div", "item-head");
+                head.appendChild(el("span", "item-title", v.title));
+                head.appendChild(el("span", "arrow", "\u2192"));
+                a.appendChild(head);
+                videosList.appendChild(a);
+            });
+        }
+    }
+
+    function setupReveal() {
+        const items = document.querySelectorAll(".reveal");
+        if (!("IntersectionObserver" in window) || items.length === 0) {
+            items.forEach(function (i) {
+                i.classList.add("is-visible");
+            });
+            return;
+        }
+        const io = new IntersectionObserver(
+            function (entries) {
+                entries.forEach(function (entry) {
+                    if (entry.isIntersecting) {
+                        entry.target.classList.add("is-visible");
+                        io.unobserve(entry.target);
+                    }
+                });
+            },
+            { threshold: 0.08 }
+        );
+        items.forEach(function (i) {
+            io.observe(i);
+        });
+    }
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,470 @@
+/* ==========================================================================
+   Issack John — personal site
+   Hand-tuned, dependency-free CSS. No runtime framework (fast by design).
+   ========================================================================== */
+
+:root {
+    color-scheme: light dark;
+
+    --max-width: 44rem;
+    --radius: 14px;
+    --radius-sm: 10px;
+
+    /* Light theme */
+    --bg: #f7f8fa;
+    --bg-elev: #ffffff;
+    --bg-subtle: #f1f3f6;
+    --border: #e6e9ef;
+    --text: #1a1f29;
+    --text-muted: #5b6472;
+    --text-faint: #8a93a3;
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --accent-soft: rgba(37, 99, 235, 0.1);
+    --shadow: 0 1px 2px rgba(16, 24, 40, 0.04), 0 8px 24px rgba(16, 24, 40, 0.06);
+    --shadow-hover: 0 2px 4px rgba(16, 24, 40, 0.06), 0 16px 40px rgba(16, 24, 40, 0.1);
+    --ring: 0 0 0 3px var(--accent-soft);
+}
+
+[data-theme="dark"] {
+    --bg: #0c0e13;
+    --bg-elev: #14171f;
+    --bg-subtle: #1a1e28;
+    --border: #262b36;
+    --text: #e8ebf0;
+    --text-muted: #a3acbb;
+    --text-faint: #6b7484;
+    --accent: #6ea8ff;
+    --accent-hover: #93beff;
+    --accent-soft: rgba(110, 168, 255, 0.14);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5);
+    --shadow-hover: 0 2px 4px rgba(0, 0, 0, 0.5), 0 16px 40px rgba(0, 0, 0, 0.6);
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+        --bg: #0c0e13;
+        --bg-elev: #14171f;
+        --bg-subtle: #1a1e28;
+        --border: #262b36;
+        --text: #e8ebf0;
+        --text-muted: #a3acbb;
+        --text-faint: #6b7484;
+        --accent: #6ea8ff;
+        --accent-hover: #93beff;
+        --accent-soft: rgba(110, 168, 255, 0.14);
+        --shadow: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 24px rgba(0, 0, 0, 0.5);
+        --shadow-hover: 0 2px 4px rgba(0, 0, 0, 0.5), 0 16px 40px rgba(0, 0, 0, 0.6);
+    }
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family:
+        system-ui,
+        -apple-system,
+        "Segoe UI",
+        Roboto,
+        Helvetica,
+        Arial,
+        sans-serif,
+        "Apple Color Emoji",
+        "Segoe UI Emoji";
+    font-size: 16px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+}
+
+a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}
+
+:focus-visible {
+    outline: none;
+    box-shadow: var(--ring);
+    border-radius: 6px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #fff;
+    padding: 0.6rem 1rem;
+    border-radius: 0 0 8px 0;
+    z-index: 100;
+}
+
+.skip-link:focus {
+    left: 0;
+}
+
+/* Layout ------------------------------------------------------------------ */
+
+.wrap {
+    max-width: var(--max-width);
+    margin: 0 auto;
+    padding: 0 1.25rem;
+}
+
+main {
+    padding-bottom: 4rem;
+}
+
+section {
+    margin-top: 3rem;
+}
+
+.section-title {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-faint);
+    margin: 0 0 1rem;
+}
+
+/* Top bar ----------------------------------------------------------------- */
+
+.topbar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    backdrop-filter: saturate(180%) blur(12px);
+    -webkit-backdrop-filter: saturate(180%) blur(12px);
+    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    border-bottom: 1px solid var(--border);
+}
+
+.topbar .wrap {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 56px;
+}
+
+.brand {
+    font-weight: 700;
+    color: var(--text);
+    letter-spacing: -0.01em;
+}
+
+.brand:hover {
+    text-decoration: none;
+}
+
+.theme-toggle {
+    appearance: none;
+    border: 1px solid var(--border);
+    background: var(--bg-elev);
+    color: var(--text-muted);
+    width: 38px;
+    height: 38px;
+    border-radius: 10px;
+    cursor: pointer;
+    display: inline-grid;
+    place-items: center;
+    transition:
+        color 0.15s ease,
+        border-color 0.15s ease,
+        background 0.15s ease;
+}
+
+.theme-toggle:hover {
+    color: var(--text);
+    border-color: var(--text-faint);
+}
+
+.theme-toggle svg {
+    width: 18px;
+    height: 18px;
+}
+
+.theme-toggle .icon-sun {
+    display: none;
+}
+
+[data-theme="dark"] .theme-toggle .icon-sun {
+    display: block;
+}
+
+[data-theme="dark"] .theme-toggle .icon-moon {
+    display: none;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .theme-toggle .icon-sun {
+        display: block;
+    }
+    :root:not([data-theme="light"]) .theme-toggle .icon-moon {
+        display: none;
+    }
+}
+
+/* Hero -------------------------------------------------------------------- */
+
+.hero {
+    text-align: center;
+    padding: 3.5rem 0 1rem;
+}
+
+.avatar {
+    width: 84px;
+    height: 84px;
+    border-radius: 50%;
+    margin: 0 auto 1.25rem;
+    display: grid;
+    place-items: center;
+    font-size: 2rem;
+    font-weight: 700;
+    color: #fff;
+    background: linear-gradient(135deg, var(--accent), #7c3aed);
+    box-shadow: var(--shadow);
+}
+
+.hero h1 {
+    font-size: clamp(2rem, 6vw, 2.75rem);
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    margin: 0 0 0.5rem;
+}
+
+.hero .role {
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    margin: 0;
+}
+
+.hero .tagline {
+    color: var(--text-faint);
+    margin: 0.4rem 0 0;
+}
+
+.social {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+}
+
+.social a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--bg-elev);
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition:
+        color 0.15s ease,
+        border-color 0.15s ease,
+        transform 0.15s ease;
+}
+
+.social a:hover {
+    color: var(--text);
+    border-color: var(--text-faint);
+    text-decoration: none;
+    transform: translateY(-1px);
+}
+
+.social svg {
+    width: 16px;
+    height: 16px;
+}
+
+/* Cards & content --------------------------------------------------------- */
+
+.card {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 1.5rem;
+    box-shadow: var(--shadow);
+}
+
+.prose p {
+    margin: 0 0 0.85rem;
+    color: var(--text-muted);
+}
+
+.prose p:last-child {
+    margin-bottom: 0;
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 1.1rem;
+}
+
+.tag {
+    font-size: 0.78rem;
+    font-weight: 500;
+    padding: 0.3rem 0.65rem;
+    border-radius: 999px;
+    background: var(--bg-subtle);
+    color: var(--text-muted);
+    border: 1px solid var(--border);
+}
+
+/* Project / link list ----------------------------------------------------- */
+
+.stack {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.item {
+    display: block;
+    padding: 1rem 1.1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-elev);
+    box-shadow: var(--shadow);
+    transition:
+        transform 0.15s ease,
+        box-shadow 0.15s ease,
+        border-color 0.15s ease;
+}
+
+.item:hover {
+    text-decoration: none;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-hover);
+    border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
+}
+
+.item-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.item-title {
+    font-weight: 600;
+    color: var(--text);
+}
+
+.item-date {
+    font-size: 0.78rem;
+    color: var(--text-faint);
+    white-space: nowrap;
+}
+
+.item-desc {
+    margin: 0.3rem 0 0;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.item .arrow {
+    color: var(--accent);
+    transition: transform 0.15s ease;
+    display: inline-block;
+}
+
+.item:hover .arrow {
+    transform: translateX(3px);
+}
+
+/* Blog -------------------------------------------------------------------- */
+
+.post {
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    padding: 1.1rem 1.25rem;
+    background: var(--bg-subtle);
+}
+
+.post h3 {
+    margin: 0 0 0.35rem;
+    font-size: 1.05rem;
+    color: var(--text);
+}
+
+.post p {
+    margin: 0 0 0.85rem;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+}
+
+.post-foot {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.post-foot time {
+    font-size: 0.78rem;
+    color: var(--text-faint);
+}
+
+/* Footer ------------------------------------------------------------------ */
+
+.site-footer {
+    border-top: 1px solid var(--border);
+    margin-top: 4rem;
+    padding: 2rem 0;
+    text-align: center;
+    color: var(--text-faint);
+    font-size: 0.85rem;
+}
+
+/* Reveal-on-scroll animation --------------------------------------------- */
+
+.reveal {
+    opacity: 0;
+    transform: translateY(14px);
+    transition:
+        opacity 0.5s ease,
+        transform 0.5s ease;
+}
+
+.reveal.is-visible {
+    opacity: 1;
+    transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        transition-duration: 0.001ms !important;
+    }
+    .reveal {
+        opacity: 1;
+        transform: none;
+    }
+}

--- a/complex-workloads.html
+++ b/complex-workloads.html
@@ -11,7 +11,7 @@
                 <h1>Speedometer 3.0 Test Runner</h1>
                 <ul>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer"> All tests</a>
+                        <a href="https://issackjohn.github.io/Speedometer" target="_blank" rel="noopener noreferrer"> All tests</a>
                     </li>
                 </ul>
                 <h3>Vanilla</h3>
@@ -30,40 +30,40 @@
                 </div>
             </div>
             <div>
-                <h1>Complex Workoads</h1>
+                <h1>Complex Workloads</h1>
                 <ul>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/angular-complex/dist/">Angular</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/angular-complex/dist/" target="_blank" rel="noopener noreferrer">Angular</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/backbone-complex/dist/">Backbone</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/backbone-complex/dist/" target="_blank" rel="noopener noreferrer">Backbone</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/jquery-complex/dist/">Jquery</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/jquery-complex/dist/" target="_blank" rel="noopener noreferrer">Jquery</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es5-complex/dist/">JavaScript-es5</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es5-complex/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es5</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-complex/dist/">JavaScript-es6</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-complex/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es6</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-webpack-complex/dist/">JavaScript-es6-webpack</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-webpack-complex/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es6-webpack</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/preact-complex/dist/">Preact</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/preact-complex/dist/" target="_blank" rel="noopener noreferrer">Preact</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-complex/dist/">React</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-complex/dist/" target="_blank" rel="noopener noreferrer">React</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-redux-complex/dist/">React-Redux</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-redux-complex/dist/" target="_blank" rel="noopener noreferrer">React-Redux</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/svelte-complex/dist/">Svelte</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/svelte-complex/dist/" target="_blank" rel="noopener noreferrer">Svelte</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/vue-complex/dist/">Vue</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/vue-complex/dist/" target="_blank" rel="noopener noreferrer">Vue</a>
                     </li>
                 </ul>
             </div>
@@ -71,37 +71,37 @@
                 <h1>Workloads</h1>
                 <ul>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/angular/dist/">Angular</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/angular/dist/" target="_blank" rel="noopener noreferrer">Angular</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/backbone/dist/">Backbone</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/backbone/dist/" target="_blank" rel="noopener noreferrer">Backbone</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/jquery/dist/">Jquery</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/jquery/dist/" target="_blank" rel="noopener noreferrer">Jquery</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es5/dist/">JavaScript-es5</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es5/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es5</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6/dist/">JavaScript-es6</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es6</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-webpack/dist/">JavaScript-es6-webpack</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/vanilla-examples/javascript-es6-webpack/dist/" target="_blank" rel="noopener noreferrer">JavaScript-es6-webpack</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/preact/dist/">Preact</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/preact/dist/" target="_blank" rel="noopener noreferrer">Preact</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react/dist/">React</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react/dist/" target="_blank" rel="noopener noreferrer">React</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-redux/dist/">React-Redux</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/react-redux/dist/" target="_blank" rel="noopener noreferrer">React-Redux</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/svelte/dist/">Svelte</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/svelte/dist/" target="_blank" rel="noopener noreferrer">Svelte</a>
                     </li>
                     <li>
-                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/vue/dist/">Vue</a>
+                        <a href="https://issackjohn.github.io/Speedometer/resources/todomvc/architecture-examples/vue/dist/" target="_blank" rel="noopener noreferrer">Vue</a>
                     </li>
                 </ul>
             </div>
@@ -162,6 +162,8 @@
                 const li = document.createElement("li");
                 const a = document.createElement("a");
                 a.href = `https://issackjohn.github.io/Speedometer?suite=${value}`;
+                a.target = "_blank";
+                a.rel = "noopener noreferrer";
                 a.innerText = key;
                 li.appendChild(a);
                 testRunner.appendChild(li);
@@ -172,6 +174,8 @@
                 const li = document.createElement("li");
                 const a = document.createElement("a");
                 a.href = `https://issackjohn.github.io/Speedometer?suite=${value}`;
+                a.target = "_blank";
+                a.rel = "noopener noreferrer";
                 a.innerText = key;
                 li.appendChild(a);
                 complexTestRunner.appendChild(li);

--- a/index.html
+++ b/index.html
@@ -1,153 +1,140 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme-default>
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Issack John — Web Performance Engineer</title>
-        <meta name="description" content="Issack John — Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0 and web benchmarking research." />
-        <meta property="og:title" content="Issack John — Web Performance Engineer" />
-        <meta property="og:description" content="Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0 and web benchmarking research." />
+
+        <meta name="description" content="Issack John is a Web Performance Engineer at Microsoft Edge and a core contributor to Speedometer 3.0, the industry-standard browser benchmark." />
+        <meta name="author" content="Issack John" />
+        <meta name="theme-color" content="#2563eb" />
+        <link rel="canonical" href="https://issackjohn.github.io/" />
+
+        <!-- Open Graph / Twitter -->
         <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://issackjohn.github.io" />
-        <link rel="canonical" href="https://issackjohn.github.io" />
-        <script src="https://cdn.tailwindcss.com"></script>
+        <meta property="og:url" content="https://issackjohn.github.io/" />
+        <meta property="og:title" content="Issack John — Web Performance Engineer" />
+        <meta property="og:description" content="Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0." />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content="Issack John — Web Performance Engineer" />
+        <meta name="twitter:description" content="Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0." />
+
+        <link rel="icon" type="image/svg+xml" href="/assets/favicon.svg" />
+        <link rel="preload" href="/assets/styles.css" as="style" />
+        <link rel="stylesheet" href="/assets/styles.css" />
+
+        <!-- Avoid theme flash: apply stored preference before paint. -->
+        <script>
+            (function () {
+                try {
+                    var t = localStorage.getItem("theme");
+                    if (t === "light" || t === "dark") {
+                        document.documentElement.setAttribute("data-theme", t);
+                    }
+                } catch (e) {}
+            })();
+        </script>
+
+        <!-- Structured data for search engines -->
+        <script type="application/ld+json">
+            {
+                "@context": "https://schema.org",
+                "@type": "Person",
+                "name": "Issack John",
+                "url": "https://issackjohn.github.io/",
+                "jobTitle": "Web Performance Engineer",
+                "worksFor": { "@type": "Organization", "name": "Microsoft Edge" },
+                "knowsAbout": ["Web Performance", "Browser Benchmarking", "Speedometer 3.0", "JavaScript"],
+                "sameAs": ["https://github.com/issackjohn", "https://blogs.windows.com/msedgedev/author/issackjohn/"]
+            }
+        </script>
     </head>
-    <body class="bg-gray-50 min-h-screen flex flex-col items-center py-10">
-        <main class="w-full max-w-xl mx-auto px-6 flex flex-col gap-8">
-            <header class="flex flex-col items-center gap-3">
-                <h1 class="text-4xl font-extrabold text-gray-900 tracking-tight">Issack John</h1>
-                <p class="text-gray-500 text-lg text-center">Web Performance &amp; Simplicity · Microsoft Edge</p>
-                <nav class="flex gap-5 mt-1" aria-label="Social links">
-                    <a href="https://github.com/issackjohn" target="_blank" rel="noopener noreferrer"
-                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
+    <body>
+        <a class="skip-link" href="#main">Skip to content</a>
+
+        <div class="topbar">
+            <div class="wrap">
+                <a class="brand" href="/">Issack John</a>
+                <button id="themeToggle" class="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
+                    <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+                    </svg>
+                    <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <circle cx="12" cy="12" r="4" />
+                        <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        <main id="main" class="wrap">
+            <!-- Hero -->
+            <header class="hero">
+                <div class="avatar" aria-hidden="true">IJ</div>
+                <h1>Issack John</h1>
+                <p class="role">Web Performance Engineer · Microsoft Edge</p>
+                <p class="tagline">Building a faster, simpler web.</p>
+
+                <nav class="social" aria-label="Profiles and links">
+                    <a href="https://github.com/issackjohn" target="_blank" rel="noopener noreferrer">
+                        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                            <path
+                                d="M12 .5C5.73.5.5 5.74.5 12.02c0 5.08 3.29 9.39 7.86 10.91.58.11.79-.25.79-.56 0-.27-.01-1.16-.02-2.1-3.2.7-3.88-1.37-3.88-1.37-.52-1.33-1.28-1.69-1.28-1.69-1.05-.72.08-.7.08-.7 1.16.08 1.77 1.19 1.77 1.19 1.03 1.77 2.7 1.26 3.36.96.1-.75.4-1.26.73-1.55-2.56-.29-5.26-1.28-5.26-5.71 0-1.26.45-2.29 1.19-3.1-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 2.9-.39c.98 0 1.97.13 2.9.39 2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.19 1.84 1.19 3.1 0 4.44-2.7 5.42-5.27 5.7.41.36.78 1.07.78 2.16 0 1.56-.01 2.82-.01 3.2 0 .31.21.68.8.56A11.53 11.53 0 0 0 23.5 12.02C23.5 5.74 18.27.5 12 .5z"
+                            />
+                        </svg>
                         GitHub
                     </a>
-                    <a href="https://blogs.windows.com/msedgedev/author/issackjohn/" target="_blank" rel="noopener noreferrer"
-                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
-                        Blog
-                    </a>
-                    <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer"
-                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
-                        Speedometer 3.0
-                    </a>
+                    <a href="https://blogs.windows.com/msedgedev/author/issackjohn/" target="_blank" rel="noopener noreferrer"> Blog </a>
+                    <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer"> Speedometer 3.0 </a>
                 </nav>
             </header>
 
-            <!-- About Section -->
-            <section class="bg-white rounded-xl shadow p-6">
-                <h2 class="text-xl font-semibold text-gray-800 mb-3">About</h2>
-                <p class="text-gray-600 text-sm leading-relaxed">
-                    Software engineer at Microsoft Edge focused on web performance and browser benchmarking.
-                    Core contributor to <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">Speedometer 3.0</a>,
-                    the industry-standard browser benchmark designed to capture real-world web application performance challenges.
-                </p>
-            </section>
-
-            <!-- Blog Posts Section -->
-            <section class="bg-white rounded-xl shadow p-6 flex flex-col gap-4">
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Latest Blog Posts</h2>
-                <div id="blogPostsList" class="flex flex-col gap-4"></div>
-            </section>
-
-            <!-- Projects Section -->
-            <section class="bg-white rounded-xl shadow p-6 flex flex-col gap-4">
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Projects &amp; Tools</h2>
-                <div class="flex flex-col gap-3">
-                    <a href="/speedometer.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
-                        <div class="font-medium text-gray-900">Speedometer 3.0 Test Runner</div>
-                        <div class="text-xs text-gray-500 mt-1">Compare benchmark suites side-by-side · January 2024</div>
-                    </a>
-                    <a href="/speedometer-with-complex.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
-                        <div class="font-medium text-gray-900">Speedometer with Complex DOM</div>
-                        <div class="text-xs text-gray-500 mt-1">Benchmark experiments using complex DOM structures · June 2023</div>
-                    </a>
-                    <a href="/speedometer-with-new-structure.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
-                        <div class="font-medium text-gray-900">Speedometer — New Structure Complex DOM</div>
-                        <div class="text-xs text-gray-500 mt-1">Updated architecture experiments · September 2023</div>
-                    </a>
-                    <a href="https://issackjohn.github.io/SpeedometerJSWebComponents" target="_blank" rel="noopener noreferrer"
-                       class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
-                        <div class="font-medium text-gray-900">JavaScript Web Components Speedometer</div>
-                        <div class="text-xs text-gray-500 mt-1">TodoMVC benchmark using native Web Components</div>
-                    </a>
-                    <a href="/complex-workloads.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
-                        <div class="font-medium text-gray-900">Complex Workloads Explorer</div>
-                        <div class="text-xs text-gray-500 mt-1">Browse and launch individual complex benchmark workloads</div>
-                    </a>
+            <!-- About -->
+            <section class="reveal" aria-labelledby="about-title">
+                <h2 class="section-title" id="about-title">About</h2>
+                <div class="card prose">
+                    <p>
+                        I'm a software engineer at Microsoft Edge focused on web performance and browser benchmarking. I'm a core contributor to
+                        <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer">Speedometer 3.0</a>, the cross-browser benchmark — built by Apple, Google, Microsoft, and Mozilla — that measures how browsers handle
+                        the demands of real-world web applications.
+                    </p>
+                    <p>My work centers on making the web measurably faster: profiling real workloads, designing representative benchmarks, and chasing simplicity in the process.</p>
+                    <div class="tags" aria-label="Focus areas">
+                        <span class="tag">Web Performance</span>
+                        <span class="tag">Browser Benchmarking</span>
+                        <span class="tag">Speedometer 3.0</span>
+                        <span class="tag">JavaScript</span>
+                        <span class="tag">DOM</span>
+                    </div>
                 </div>
             </section>
 
-            <!-- Videos Section -->
-            <section class="bg-white rounded-xl shadow p-6 flex flex-col gap-4">
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Recommended Videos</h2>
-                <ul id="videosList" class="flex flex-col gap-2"></ul>
+            <!-- Projects -->
+            <section class="reveal" aria-labelledby="projects-title">
+                <h2 class="section-title" id="projects-title">Projects &amp; Tools</h2>
+                <div class="stack" id="projectsList"></div>
             </section>
 
-            <footer class="text-center text-xs text-gray-400 pb-6">&copy; 2025 Issack John</footer>
+            <!-- Blog -->
+            <section class="reveal" aria-labelledby="writing-title">
+                <h2 class="section-title" id="writing-title">Writing</h2>
+                <div class="stack" id="blogPostsList"></div>
+            </section>
+
+            <!-- Videos -->
+            <section class="reveal" aria-labelledby="watching-title">
+                <h2 class="section-title" id="watching-title">Recommended Watching</h2>
+                <div class="stack" id="videosList"></div>
+            </section>
         </main>
+
+        <footer class="site-footer">
+            <div class="wrap">&copy; <span id="year">2025</span> Issack John · Built for speed, no frameworks.</div>
+        </footer>
+
+        <script src="/assets/main.js" defer></script>
         <script>
-            const blogPosts = [
-                {
-                    title: "Contributing to Speedometer 3.0",
-                    summary: "How the team captured real-world web challenges in the industry-standard browser benchmark.",
-                    url: "https://blogs.windows.com/msedgedev/2024/03/11/contributing-to-speedometer-30/",
-                    date: "March 11, 2024",
-                },
-            ];
-
-            const blogPostsList = document.getElementById("blogPostsList");
-            blogPosts.forEach((post) => {
-                const article = document.createElement("article");
-                article.className = "rounded-lg border border-gray-100 p-4 bg-gray-50 flex flex-col gap-2";
-
-                const h3 = document.createElement("h3");
-                h3.textContent = post.title;
-                h3.className = "text-base font-bold text-gray-900";
-
-                const p = document.createElement("p");
-                p.textContent = post.summary;
-                p.className = "text-sm text-gray-600";
-
-                const footer = document.createElement("div");
-                footer.className = "flex items-center justify-between";
-
-                const a = document.createElement("a");
-                a.href = post.url;
-                a.target = "_blank";
-                a.rel = "noopener noreferrer";
-                a.textContent = "Read more →";
-                a.className = "text-blue-500 hover:underline text-sm";
-
-                const time = document.createElement("time");
-                time.textContent = post.date;
-                time.className = "text-xs text-gray-400";
-
-                footer.appendChild(a);
-                footer.appendChild(time);
-                article.appendChild(h3);
-                article.appendChild(p);
-                article.appendChild(footer);
-                blogPostsList.appendChild(article);
-            });
-
-            document.addEventListener("DOMContentLoaded", function () {
-                const videos = [
-                    { url: "https://youtu.be/Lp3e1C54jZM?si=S_DvlMjmYVTo4exo", title: "Jim Rohn — Give To Receive" },
-                ];
-
-                const videosList = document.getElementById("videosList");
-                videos.forEach((video) => {
-                    const li = document.createElement("li");
-                    const a = document.createElement("a");
-                    a.href = video.url;
-                    a.target = "_blank";
-                    a.rel = "noopener noreferrer";
-                    a.textContent = video.title;
-                    a.className = "text-blue-500 hover:underline text-sm";
-                    li.appendChild(a);
-                    videosList.appendChild(li);
-                });
-            });
+            document.getElementById("year").textContent = new Date().getFullYear();
         </script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,15 +3,45 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Issack John</title>
+        <title>Issack John — Web Performance Engineer</title>
+        <meta name="description" content="Issack John — Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0 and web benchmarking research." />
+        <meta property="og:title" content="Issack John — Web Performance Engineer" />
+        <meta property="og:description" content="Web Performance Engineer at Microsoft Edge. Core contributor to Speedometer 3.0 and web benchmarking research." />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://issackjohn.github.io" />
+        <link rel="canonical" href="https://issackjohn.github.io" />
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
-    <body class="bg-gray-50 min-h-screen flex flex-col justify-center items-center">
-        <main class="w-full max-w-md mx-auto p-6 flex flex-col gap-8">
-            <header class="flex flex-col items-center gap-2">
+    <body class="bg-gray-50 min-h-screen flex flex-col items-center py-10">
+        <main class="w-full max-w-xl mx-auto px-6 flex flex-col gap-8">
+            <header class="flex flex-col items-center gap-3">
                 <h1 class="text-4xl font-extrabold text-gray-900 tracking-tight">Issack John</h1>
-                <p class="text-gray-500 text-lg">Web Performance & Simplicity</p>
+                <p class="text-gray-500 text-lg text-center">Web Performance &amp; Simplicity · Microsoft Edge</p>
+                <nav class="flex gap-5 mt-1" aria-label="Social links">
+                    <a href="https://github.com/issackjohn" target="_blank" rel="noopener noreferrer"
+                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
+                        GitHub
+                    </a>
+                    <a href="https://blogs.windows.com/msedgedev/author/issackjohn/" target="_blank" rel="noopener noreferrer"
+                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
+                        Blog
+                    </a>
+                    <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer"
+                       class="text-gray-500 hover:text-gray-900 transition text-sm font-medium">
+                        Speedometer 3.0
+                    </a>
+                </nav>
             </header>
+
+            <!-- About Section -->
+            <section class="bg-white rounded-xl shadow p-6">
+                <h2 class="text-xl font-semibold text-gray-800 mb-3">About</h2>
+                <p class="text-gray-600 text-sm leading-relaxed">
+                    Software engineer at Microsoft Edge focused on web performance and browser benchmarking.
+                    Core contributor to <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">Speedometer 3.0</a>,
+                    the industry-standard browser benchmark designed to capture real-world web application performance challenges.
+                </p>
+            </section>
 
             <!-- Blog Posts Section -->
             <section class="bg-white rounded-xl shadow p-6 flex flex-col gap-4">
@@ -21,22 +51,28 @@
 
             <!-- Projects Section -->
             <section class="bg-white rounded-xl shadow p-6 flex flex-col gap-4">
-                <h2 class="text-xl font-semibold text-gray-800 mb-2">Featured Projects</h2>
+                <h2 class="text-xl font-semibold text-gray-800 mb-2">Projects &amp; Tools</h2>
                 <div class="flex flex-col gap-3">
-                    <a href="https://issackjohn.github.io/speedometer.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 transition">
-                        <div class="font-medium text-gray-900">Speedometer 3.0 <span class="text-xs text-gray-400">2024-01-24</span></div>
+                    <a href="/speedometer.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
+                        <div class="font-medium text-gray-900">Speedometer 3.0 Test Runner</div>
+                        <div class="text-xs text-gray-500 mt-1">Compare benchmark suites side-by-side · January 2024</div>
                     </a>
-                    <a href="https://issackjohn.github.io/complex-workloads.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 transition">
-                        <div class="font-medium text-gray-900">Complex Workloads</div>
+                    <a href="/speedometer-with-complex.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
+                        <div class="font-medium text-gray-900">Speedometer with Complex DOM</div>
+                        <div class="text-xs text-gray-500 mt-1">Benchmark experiments using complex DOM structures · June 2023</div>
                     </a>
-                    <a href="https://issackjohn.github.io/speedometer-with-complex.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 transition">
-                        <div class="font-medium text-gray-900">2023-06-27 With Complex DOM</div>
+                    <a href="/speedometer-with-new-structure.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
+                        <div class="font-medium text-gray-900">Speedometer — New Structure Complex DOM</div>
+                        <div class="text-xs text-gray-500 mt-1">Updated architecture experiments · September 2023</div>
                     </a>
-                    <a href="https://issackjohn.github.io/speedometer" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 transition">
-                        <div class="font-medium text-gray-900">2023-09-18 With New Structure Complex DOM</div>
+                    <a href="https://issackjohn.github.io/SpeedometerJSWebComponents" target="_blank" rel="noopener noreferrer"
+                       class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
+                        <div class="font-medium text-gray-900">JavaScript Web Components Speedometer</div>
+                        <div class="text-xs text-gray-500 mt-1">TodoMVC benchmark using native Web Components</div>
                     </a>
-                    <a href="https://issackjohn.github.io/SpeedometerJSWebComponents" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 transition">
-                        <div class="font-medium text-gray-900">JavaScript Web Components</div>
+                    <a href="/complex-workloads.html" class="block p-3 rounded-lg border border-gray-200 hover:bg-blue-50 hover:border-blue-200 transition">
+                        <div class="font-medium text-gray-900">Complex Workloads Explorer</div>
+                        <div class="text-xs text-gray-500 mt-1">Browse and launch individual complex benchmark workloads</div>
                     </a>
                 </div>
             </section>
@@ -47,53 +83,65 @@
                 <ul id="videosList" class="flex flex-col gap-2"></ul>
             </section>
 
-            <footer class="text-center text-xs text-gray-400 mt-8">&copy; 2025 Issack John</footer>
+            <footer class="text-center text-xs text-gray-400 pb-6">&copy; 2025 Issack John</footer>
         </main>
         <script>
-            // title, summary, url
             const blogPosts = [
                 {
                     title: "Contributing to Speedometer 3.0",
-                    summary: "Capturing real-world challenges on the web",
+                    summary: "How the team captured real-world web challenges in the industry-standard browser benchmark.",
                     url: "https://blogs.windows.com/msedgedev/2024/03/11/contributing-to-speedometer-30/",
+                    date: "March 11, 2024",
                 },
             ];
 
             const blogPostsList = document.getElementById("blogPostsList");
-
             blogPosts.forEach((post) => {
                 const article = document.createElement("article");
                 article.className = "rounded-lg border border-gray-100 p-4 bg-gray-50 flex flex-col gap-2";
 
                 const h3 = document.createElement("h3");
                 h3.textContent = post.title;
-                h3.className = "text-lg font-bold text-gray-900";
+                h3.className = "text-base font-bold text-gray-900";
 
                 const p = document.createElement("p");
                 p.textContent = post.summary;
                 p.className = "text-sm text-gray-600";
 
+                const footer = document.createElement("div");
+                footer.className = "flex items-center justify-between";
+
                 const a = document.createElement("a");
                 a.href = post.url;
-                a.textContent = "Read more";
-                a.className = "text-blue-500 hover:underline text-sm w-fit";
+                a.target = "_blank";
+                a.rel = "noopener noreferrer";
+                a.textContent = "Read more →";
+                a.className = "text-blue-500 hover:underline text-sm";
 
+                const time = document.createElement("time");
+                time.textContent = post.date;
+                time.className = "text-xs text-gray-400";
+
+                footer.appendChild(a);
+                footer.appendChild(time);
                 article.appendChild(h3);
                 article.appendChild(p);
-                article.appendChild(a);
-
+                article.appendChild(footer);
                 blogPostsList.appendChild(article);
             });
-            // JavaScript for dynamically adding video links
+
             document.addEventListener("DOMContentLoaded", function () {
-                const videos = [{ url: "https://youtu.be/Lp3e1C54jZM?si=S_DvlMjmYVTo4exo", title: "Jim Rohn - Give To Receive" }];
+                const videos = [
+                    { url: "https://youtu.be/Lp3e1C54jZM?si=S_DvlMjmYVTo4exo", title: "Jim Rohn — Give To Receive" },
+                ];
 
                 const videosList = document.getElementById("videosList");
-
                 videos.forEach((video) => {
                     const li = document.createElement("li");
                     const a = document.createElement("a");
                     a.href = video.url;
+                    a.target = "_blank";
+                    a.rel = "noopener noreferrer";
                     a.textContent = video.title;
                     a.className = "text-blue-500 hover:underline text-sm";
                     li.appendChild(a);

--- a/speedometer.html
+++ b/speedometer.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Complex workloads</title>
+        <title>Speedometer 3.0 Test Runner</title>
         <script src="https://cdn.tailwindcss.com"></script>
     </head>
     <body class="bg-gray-100">


### PR DESCRIPTION
## Summary

A significant upgrade to the personal site — rebuilt around the idea that a *web-performance engineer's* site should itself be fast, accessible, and dependency-free.

## Homepage redesign (`index.html` + `assets/`)
- **Dropped the Tailwind CDN** (a known perf/JIT-in-prod anti-pattern) for hand-tuned CSS in `assets/styles.css`. No runtime framework, no build step.
- **Dark mode** that follows the OS preference and remembers a manual toggle — with an inline pre-paint script so there's no flash on load.
- **New structure**: sticky top bar with brand + theme toggle, a hero with avatar/role/tagline, an **About** section with focus-area tags, and richer Projects / Writing / Watching cards rendered from data in `assets/main.js`.
- **Accessibility**: skip link, semantic landmarks + `aria-labelledby`, visible focus rings, full `prefers-reduced-motion` support.
- **SEO**: meta description, Open Graph + Twitter tags, canonical URL, JSON-LD `Person` structured data.
- **Favicon**: inline gradient 'IJ' SVG mark.

## New: `404.html`
Friendly not-found page reusing the shared styles and theme.

## Earlier fixes (also in this PR)
- `speedometer.html`: corrected `<title>` (was 'Complex workloads').
- `complex-workloads.html`: fixed 'Complex Workoads' typo and hardened external links.

## README
Rewritten with project structure, highlights, the pages/submodules tables, and the **correct** npm scripts.

## Verification
- Prettier-formatted to match repo config.
- `node --check` on `main.js`; JSON-LD parsed and validated.
- Served locally — `/`, all `assets/*`, `404.html`, and benchmark pages return `200` with correct content types.