### PR TITLE
Fix broken blog link on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 "jobTitle": "Web Performance Engineer",
                 "worksFor": { "@type": "Organization", "name": "Microsoft Edge" },
                 "knowsAbout": ["Web Performance", "Browser Benchmarking", "Speedometer 3.0", "JavaScript"],
-                "sameAs": ["https://github.com/issackjohn", "https://blogs.windows.com/msedgedev/author/issackjohn/"]
+                "sameAs": ["https://github.com/issackjohn", "https://blogs.windows.com/msedgedev/"]
             }
         </script>
     </head>
@@ -84,7 +84,7 @@
                         </svg>
                         GitHub
                     </a>
-                    <a href="https://blogs.windows.com/msedgedev/author/issackjohn/" target="_blank" rel="noopener noreferrer"> Blog </a>
+                    <a href="https://blogs.windows.com/msedgedev/" target="_blank" rel="noopener noreferrer"> Blog </a>
                     <a href="https://browserbench.org/Speedometer3.0/" target="_blank" rel="noopener noreferrer"> Speedometer 3.0 </a>
                 </nav>
             </header>


### PR DESCRIPTION
## Fix
The Blog URL used in the homepage social links was pointing to:
- `https://blogs.windows.com/msedgedev/author/issackjohn/` (404)

Updated it to:
- `https://blogs.windows.com/msedgedev/` (200)

## Updated locations
- `index.html` social nav Blog link
- `index.html` JSON-LD `sameAs` entry

This restores a working outbound blog link and keeps structured data consistent.
